### PR TITLE
Add .NET and IDE gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Build results
+bin/
+obj/
+out/
+
+# Visual Studio files
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Rider/JetBrains
+.idea/
+
+# Logs, coverage, and temporary files
+*.log
+*.tsbuildinfo
+coverage/
+*.DS_Store
+
+# Packages
+packages/
+*.nupkg


### PR DESCRIPTION
## Summary
- ignore typical .NET build outputs, IDE files, logs, and packages

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_689b76eac788833287f9852251153023