### PR TITLE
Expand gitignore and fix workflow publish path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet test --no-build --verbosity normal
 
       - name: Publish artifacts
-        run: dotnet publish src/markdown-to-pdf/markdown-to-pdf.csproj \
+        run: dotnet publish markdown-to-pdf.csproj \
                             --configuration Release --output published
         # Upload build output (optional)
       - uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,21 @@ coverage/
 # Packages
 packages/
 *.nupkg
+
+# Test results
+TestResults/
+
+# VS Code settings
+.vscode/
+
+# dotnet publish output
+published/
+
+# SQLite databases
+*.db
+*.db-shm
+*.db-wal
+
+# Miscellaneous
+*.swp
+*.tmp


### PR DESCRIPTION
## Summary
- extend .gitignore with test, publish, VS Code, SQLite, and misc file patterns
- correct GitHub Actions publish step to reference root project

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b5bacd7a08332933efb73acdb6eb7