### PR TITLE
Simplify publish step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
         run: dotnet test --no-build --verbosity normal
 
       - name: Publish artifacts
-        run: dotnet publish src/markdown-to-pdf/markdown-to-pdf.csproj \
-                            --configuration Release --output published
+        run: dotnet publish markdown-to-pdf.csproj --configuration Release --output published
         # Upload build output (optional)
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- simplify CI publish step to use single-line command

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b85be83a88332b8adea5e20966f13