### PR TITLE
Add sample markdown conversion to fillable PDF

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -1,21 +1,60 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Markdig;
 using markdown_to_pdf.Models;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using iText.Html2pdf;
+using iText.Kernel.Pdf;
 
 namespace markdown_to_pdf.Controllers
 {
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly string _samplePath;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, IWebHostEnvironment env)
         {
             _logger = logger;
+            _samplePath = Path.Combine(env.ContentRootPath, "Samples", "markdown1.txt");
         }
 
         public IActionResult Index()
         {
-            return View();
+            var markdown = System.IO.File.ReadAllText(_samplePath);
+            return View(model: markdown);
+        }
+
+        [HttpPost]
+        public IActionResult GeneratePdf()
+        {
+            var markdown = System.IO.File.ReadAllText(_samplePath);
+            var processed = ReplaceTags(markdown);
+            var html = Markdown.ToHtml(processed);
+            using var ms = new MemoryStream();
+            var writerProps = new WriterProperties().SetCloseStream(false);
+            using var writer = new PdfWriter(ms, writerProps);
+            var props = new ConverterProperties().SetCreateAcroForm(true);
+            HtmlConverter.ConvertToPdf(html, writer, props);
+            return File(ms.ToArray(), "application/pdf", "sample.pdf");
+        }
+
+        private static string ReplaceTags(string markdown)
+        {
+            markdown = Regex.Replace(markdown,
+                @"_{2,}\s*<!--\s*\{\{text:(?<name>[^,}]+).*?\}\}\s*-->",
+                m => $"<input type=\"text\" name=\"{m.Groups["name"].Value}\" />");
+
+            markdown = Regex.Replace(markdown,
+                @"<!--\s*\{\{check:(?<name>[^,}]+).*?\}\}\s*-->",
+                m => $"<input type=\"checkbox\" name=\"{m.Groups["name"].Value}\" />");
+
+            markdown = Regex.Replace(markdown,
+                @"<!--\s*\{\{radio:(?<name>[^,}]+),group=(?<group>[^,}]+),value=(?<value>[^,}]+).*?\}\}\s*-->",
+                m => $"<input type=\"radio\" name=\"{m.Groups["group"].Value}\" value=\"{m.Groups["value"].Value}\" />");
+
+            return markdown;
         }
 
         public IActionResult Privacy()

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -2,7 +2,12 @@
     ViewData["Title"] = "Home Page";
 }
 
+@model string
+
 <div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <h1 class="display-4">Markdown Sample</h1>
+    <form method="post" asp-action="GeneratePdf">
+        <pre class="text-start">@Model</pre>
+        <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
+    </form>
 </div>

--- a/markdown-to-pdf.csproj
+++ b/markdown-to-pdf.csproj
@@ -7,4 +7,11 @@
     <RootNamespace>markdown_to_pdf</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="itext7" Version="8.0.2" />
+    <PackageReference Include="itext7.pdfhtml" Version="5.0.0" />
+    <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.2" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- load sample markdown in index page and generate fillable PDF
- replace custom tags with HTML inputs and convert via iText
- add Bouncy Castle adapter and create AcroForm to keep fields fillable
- keep PDF memory stream open so conversion output can be returned

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689b8af23de48332b83258d24ad1c6ae