### PR TITLE
Add live markdown editor with preview

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -27,9 +27,9 @@ namespace markdown_to_pdf.Controllers
         }
 
         [HttpPost]
-        public IActionResult GeneratePdf()
+        public IActionResult GeneratePdf(string? markdown)
         {
-            var markdown = System.IO.File.ReadAllText(_samplePath);
+            markdown ??= System.IO.File.ReadAllText(_samplePath);
             var processed = ReplaceTags(markdown);
             var html = Markdown.ToHtml(processed);
             using var ms = new MemoryStream();

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -4,10 +4,28 @@
 
 @model string
 
-<div class="text-center">
-    <h1 class="display-4">Markdown Sample</h1>
-    <form method="post" asp-action="GeneratePdf">
-        <pre class="text-start">@Model</pre>
-        <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
-    </form>
+<div class="row">
+    <div class="col-md-6">
+        <form method="post" asp-action="GeneratePdf">
+            <textarea id="markdownInput" name="markdown" class="form-control" rows="25">@Model</textarea>
+            <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
+        </form>
+    </div>
+    <div class="col-md-6">
+        <div id="preview" class="border p-3 h-100 overflow-auto"></div>
+    </div>
 </div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+        const input = document.getElementById('markdownInput');
+        const preview = document.getElementById('preview');
+        function updatePreview() {
+            const cleaned = input.value.replace(/<!--\s*\{\{.*?\}\}\s*-->/g, '');
+            preview.innerHTML = marked.parse(cleaned);
+        }
+        input.addEventListener('input', updatePreview);
+        updatePreview();
+    </script>
+}


### PR DESCRIPTION
## Summary
- display markdown editor beside a live preview
- send user-provided markdown to PDF generator

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b9b981b7c8332895361c190b99158