### PR TITLE
Fix checkbox and radio tag replacements in PDFs

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -48,11 +48,11 @@ namespace markdown_to_pdf.Controllers
                 m => $"<input type=\"text\" name=\"{m.Groups["name"].Value}\" />");
 
             markdown = Regex.Replace(markdown,
-                @"\[\]\s*<!--\s*\{\{check:(?<name>[^,}]+).*?\}\}\s*-->",
+                @"\[\s+]\s*<!--\s*\{\{check:(?<name>[^,}]+).*?\}\}\s*-->",
                 m => $"<input type=\"checkbox\" name=\"{m.Groups["name"].Value}\" />");
 
             markdown = Regex.Replace(markdown,
-                @"\(\)\s*<!--\s*\{\{radio:(?<name>[^,}]+),group=(?<group>[^,}]+),value=(?<value>[^,}]+).*?\}\}\s*-->",
+                @"\(\s+\)\s*<!--\s*\{\{radio:(?<name>[^,}]+),group=(?<group>[^,}]+),value=(?<value>[^,}]+).*?\}\}\s*-->",
                 m => $"<input type=\"radio\" name=\"{m.Groups["group"].Value}\" value=\"{m.Groups["value"].Value}\" />");
 
             return markdown;


### PR DESCRIPTION
## Summary
- strip placeholder `[ ]` and `( )` markers when replacing custom checkbox and radio tags

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689c964440b083329fcd353b8129ffe7