### PR TITLE
Enable Markdown table rendering in PDF output

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -31,7 +31,10 @@ namespace markdown_to_pdf.Controllers
         {
             markdown ??= System.IO.File.ReadAllText(_samplePath);
             var processed = ReplaceTags(markdown);
-            var html = Markdown.ToHtml(processed);
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .Build();
+            var html = Markdown.ToHtml(processed, pipeline);
             using var ms = new MemoryStream();
             using var writer = new PdfWriter(ms);
             writer.SetCloseStream(false);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # markdown-to-pdf
 Tool to convert markdown into pdf/fillable pdf.
+
+## Features
+
+- Converts Markdown to PDF using Markdig and iText.
+- Advanced Markdown extensions are enabled, providing support for tables and other complex Markdown constructs.


### PR DESCRIPTION
## Summary
- build Markdig pipeline with advanced extensions to properly render Markdown tables when generating PDFs
- document that advanced Markdown extensions are enabled

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689ca545a1c083328ee02ab3dbc939d8