### PR TITLE
Add Quill WYSIWYG editor with draggable placeholders

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,153 +1,25 @@
-﻿@{
+@{
     ViewData["Title"] = "Home Page";
 }
 
 @model string
 
-<ul class="nav nav-tabs d-md-none mb-3" id="mobileTabs">
-    <li class="nav-item">
-        <button class="nav-link active" id="editor-tab" type="button">Editor</button>
-    </li>
-    <li class="nav-item">
-        <button class="nav-link" id="preview-tab" type="button">Preview</button>
-    </li>
-</ul>
+<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" />
+<style>
+    .placeholder { background: #ffe; border: 1px dashed #cc0; padding: 2px 4px; display: inline-block; }
+    #placeholderToolbar .placeholder-item { cursor: grab; display: inline-block; padding: 4px 8px; margin-right: 4px; border: 1px solid #ccc; }
+</style>
 
-<div class="row">
-    <div class="col-md-6 d-md-block" id="editorPane">
-        <form method="post" asp-action="GeneratePdf">
-            <textarea id="markdownInput" name="markdown" class="form-control no-wrap" wrap="off">@Model</textarea>
-            <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
-        </form>
-    </div>
-    <div class="col-md-6 d-none d-md-block" id="previewPane">
-        <div id="preview" class="border p-3 h-100"></div>
-    </div>
-</div>
+<div id="placeholderToolbar" class="mb-2"></div>
+
+<form method="post" asp-action="GeneratePdf">
+    <div id="editor" class="form-control" style="min-height:200px;"></div>
+    <textarea id="rawInput" class="form-control d-none" wrap="off">@Model</textarea>
+    <input type="hidden" id="markdownInput" name="markdown" />
+    <button type="button" id="toggleView" class="btn btn-secondary mt-3">Toggle Raw</button>
+    <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
+</form>
 
 @section Scripts {
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script>
-        const input = document.getElementById('markdownInput');
-        const preview = document.getElementById('preview');
-        const previewScroll = preview;
-        const editorPane = document.getElementById('editorPane');
-        const previewPane = document.getElementById('previewPane');
-        const editorTab = document.getElementById('editor-tab');
-        const previewTab = document.getElementById('preview-tab');
-        let lines = [];
-        let elementMap = new Map();
-        let syncingFromInput = false;
-        let syncingFromPreview = false;
-
-        function splitParagraphLines() {
-            preview.querySelectorAll('p').forEach(p => {
-                if (p.querySelector('br')) {
-                    const fragment = document.createDocumentFragment();
-                    p.innerHTML.split(/<br\s*\/?\s*>/i).forEach(html => {
-                        const span = document.createElement('span');
-                        span.className = 'line-block';
-                        span.innerHTML = html.trim();
-                        fragment.appendChild(span);
-                    });
-                    p.replaceWith(fragment);
-                }
-            });
-        }
-
-        function updatePreview() {
-            const cleaned = input.value.replace(/<!--\s*\{\{.*?\}\}\s*-->/g, '');
-            lines = cleaned.split('\n');
-            preview.innerHTML = marked.parse(cleaned);
-            splitParagraphLines();
-            elementMap.clear();
-            const elements = Array.from(
-                preview.querySelectorAll('li, p, pre, blockquote, h1, h2, h3, h4, h5, h6, tr, .line-block')
-            ).filter(el => el.tagName === 'LI' || !el.closest('li'));
-            let index = 0;
-            for (let i = 0; i < lines.length && index < elements.length; i++) {
-                const line = lines[i];
-                if (/^\s*\|?(?:\s*:?-+:?\s*\|)+\s*:?-+:?\s*\|?\s*$/.test(line)) {
-                    continue;
-                }
-                const plain = line
-                    .replace(/<!--\s*\{\{.*?\}\}\s*-->/g, '')
-                    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
-                    .replace(/[|*_`#>\[\]-]/g, '')
-                    .replace(/\s+/g, ' ')
-                    .trim();
-                if (plain) {
-                    elementMap.set(i, elements[index++]);
-                }
-            }
-        }
-
-        function showEditor() {
-            editorPane.classList.remove('d-none');
-            previewPane.classList.add('d-none');
-            editorTab.classList.add('active');
-            previewTab.classList.remove('active');
-        }
-
-        function showPreview() {
-            previewPane.classList.remove('d-none');
-            editorPane.classList.add('d-none');
-            previewTab.classList.add('active');
-            editorTab.classList.remove('active');
-        }
-
-        function syncScroll(source, target) {
-            const percentage = source.scrollTop / (source.scrollHeight - source.clientHeight);
-            target.scrollTop = percentage * (target.scrollHeight - target.clientHeight);
-        }
-
-        editorTab.addEventListener('click', showEditor);
-        previewTab.addEventListener('click', showPreview);
-
-        input.addEventListener('input', updatePreview);
-
-        input.addEventListener('scroll', () => {
-            if (syncingFromPreview) {
-                syncingFromPreview = false;
-                return;
-            }
-            syncingFromInput = true;
-            syncScroll(input, previewScroll);
-        });
-
-        previewScroll.addEventListener('scroll', () => {
-            if (syncingFromInput) {
-                syncingFromInput = false;
-                return;
-            }
-            syncingFromPreview = true;
-            syncScroll(previewScroll, input);
-        });
-
-        function clearHighlight() {
-            preview.querySelectorAll('.highlight').forEach(el => el.classList.remove('highlight'));
-        }
-
-        function highlightPreviewLine(line) {
-            clearHighlight();
-            const target = elementMap.get(line);
-            if (target) {
-                target.classList.add('highlight');
-            }
-        }
-
-        function hoveredLine(e) {
-            const rect = input.getBoundingClientRect();
-            const lineHeight = parseInt(window.getComputedStyle(input).lineHeight);
-            return Math.floor((e.clientY - rect.top + input.scrollTop) / lineHeight);
-        }
-
-        input.addEventListener('mousemove', (e) => {
-            highlightPreviewLine(hoveredLine(e));
-        });
-
-        input.addEventListener('mouseleave', clearHighlight);
-
-        updatePreview();
-    </script>
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
 }

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,4 +1,104 @@
-﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
+// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
+//
+// Custom editor logic for inserting placeholders and toggling between
+// WYSIWYG (Quill) and raw markdown modes.
 
-// Write your JavaScript code.
+window.addEventListener('DOMContentLoaded', function () {
+    const editorContainer = document.getElementById('editor');
+    if (!editorContainer) {
+        return;
+    }
+
+    const placeholderDefs = [
+        { type: 'checkbox', label: 'Checkbox', html: '<span class="placeholder" data-type="checkbox">☐</span>' },
+        { type: 'textbox', label: 'Textbox', html: '<span class="placeholder" data-type="textbox">[__]</span>' }
+    ];
+
+    // Build toolbar
+    const toolbar = document.getElementById('placeholderToolbar');
+    placeholderDefs.forEach(ph => {
+        const item = document.createElement('div');
+        item.className = 'placeholder-item';
+        item.textContent = ph.label;
+        item.draggable = true;
+        item.dataset.type = ph.type;
+        item.addEventListener('dragstart', e => {
+            e.dataTransfer.setData('text/plain', ph.type);
+        });
+        toolbar.appendChild(item);
+    });
+
+    const quill = new Quill('#editor', { theme: 'snow' });
+    const quillEditor = editorContainer.querySelector('.ql-editor');
+
+    function insertPlaceholder(type) {
+        const def = placeholderDefs.find(p => p.type === type);
+        if (!def) return;
+        const range = quill.getSelection(true) || { index: quill.getLength(), length: 0 };
+        quill.clipboard.dangerouslyPasteHTML(range.index, def.html);
+        quill.setSelection(range.index + 1);
+    }
+
+    quillEditor.addEventListener('dragover', e => e.preventDefault());
+    quillEditor.addEventListener('drop', e => {
+        e.preventDefault();
+        const type = e.dataTransfer.getData('text/plain');
+        insertPlaceholder(type);
+    });
+
+    const rawInput = document.getElementById('rawInput');
+    const hiddenInput = document.getElementById('markdownInput');
+    const toggleBtn = document.getElementById('toggleView');
+    let rawMode = false;
+
+    function quillToRaw() {
+        let html = quill.root.innerHTML;
+        html = html.replace(/<span class="placeholder" data-type="(.*?)".*?>.*?<\/span>/g, '<!--{{$1}}-->');
+        html = html.replace(/<p><br><\/p>/g, '\n');
+        html = html.replace(/<p>/g, '').replace(/<\/p>/g, '\n');
+        html = html.replace(/<br\s*\/?>/g, '\n');
+        const div = document.createElement('div');
+        div.innerHTML = html;
+        const text = div.textContent;
+        rawInput.value = text;
+        hiddenInput.value = text;
+        return text;
+    }
+
+    function rawToQuill(text) {
+        let html = text.replace(/<!--\s*\{\{(.*?)\}\}\s*-->/g, (match, p1) => {
+            const def = placeholderDefs.find(p => p.type === p1.trim());
+            return def ? def.html : match;
+        });
+        html = html.split(/\n/).map(line => `<p>${line}</p>`).join('');
+        quill.root.innerHTML = '';
+        quill.clipboard.dangerouslyPasteHTML(html);
+    }
+
+    toggleBtn.addEventListener('click', () => {
+        if (!rawMode) {
+            quillToRaw();
+            editorContainer.classList.add('d-none');
+            rawInput.classList.remove('d-none');
+            toggleBtn.textContent = 'Toggle WYSIWYG';
+            rawMode = true;
+        } else {
+            rawToQuill(rawInput.value);
+            rawInput.classList.add('d-none');
+            editorContainer.classList.remove('d-none');
+            toggleBtn.textContent = 'Toggle Raw';
+            rawMode = false;
+        }
+    });
+
+    document.querySelector('form').addEventListener('submit', () => {
+        if (!rawMode) {
+            quillToRaw();
+        } else {
+            hiddenInput.value = rawInput.value;
+        }
+    });
+
+    rawToQuill(rawInput.value);
+});


### PR DESCRIPTION
## Summary
- Replace Markdown textarea with Quill editor and placeholder toolbar
- Add drag-and-drop toolbar to insert checkbox and textbox placeholders
- Serialize placeholders to comment tags for raw markdown mode and back to widgets for WYSIWYG

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_689cd4692d548332b4016c486f72f051