### PR TITLE
Add page break marker support

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -58,6 +58,11 @@ namespace markdown_to_pdf.Controllers
                 @"\(\s+\)\s*<!--\s*\{\{radio:(?<name>[^,}]+),group=(?<group>[^,}]+),value=(?<value>[^,}]+).*?\}\}\s*-->",
                 m => $"<input type=\"radio\" name=\"{m.Groups["group"].Value}\" value=\"{m.Groups["value"].Value}\" />");
 
+            markdown = Regex.Replace(markdown,
+                @"\s*<!--\s*\{\{\s*pagebreak\s*\}\}\s*-->\s*",
+                "\n<div style=\"page-break-after: always;\"></div>\n",
+                RegexOptions.IgnoreCase);
+
             return markdown;
         }
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ Tool to convert markdown into pdf/fillable pdf.
 
 - Converts Markdown to PDF using Markdig and iText.
 - Advanced Markdown extensions are enabled, providing support for tables and other complex Markdown constructs.
+
+## Page Breaks
+
+Insert `<!-- {{pagebreak}} -->` in your Markdown to force subsequent content to begin on a new page in the generated PDF. For example:
+
+```markdown
+First page content.
+
+<!-- {{pagebreak}} -->
+
+Second page content.
+```


### PR DESCRIPTION
## Summary
- handle `<!-- {{pagebreak}} -->` markers by emitting a page-break div
- document page break markers in README

## Testing
- `python - <<'PY'
import re, textwrap
pattern = r"\s*<!--\s*\{\{\s*pagebreak\s*\}\}\s*-->\s*"
text = textwrap.dedent('''\\
First page content.

<!-- {{pagebreak}} -->

Second page content.
''')
result = re.sub(pattern, '\n<div style="page-break-after: always;"></div>\n', text, flags=re.I)
print(result)
PY`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cd955b2888332b4441c43a47f3a6c