### PR TITLE
feat: toggle html and pdf preview

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -21,6 +21,14 @@
         </form>
     </div>
     <div class="col-md-6 d-none d-md-block" id="previewPane">
+        <div class="d-flex justify-content-end mb-2">
+            <div class="btn-group btn-group-sm" role="group">
+                <input type="radio" class="btn-check" name="previewMode" id="htmlPreview" autocomplete="off" checked>
+                <label class="btn btn-outline-secondary" for="htmlPreview">HTML</label>
+                <input type="radio" class="btn-check" name="previewMode" id="pdfPreview" autocomplete="off">
+                <label class="btn btn-outline-secondary" for="pdfPreview">PDF</label>
+            </div>
+        </div>
         <div id="preview" class="border p-3 h-100"></div>
     </div>
 </div>
@@ -35,6 +43,8 @@
         const previewPane = document.getElementById('previewPane');
         const editorTab = document.getElementById('editor-tab');
         const previewTab = document.getElementById('preview-tab');
+        const htmlMode = document.getElementById('htmlPreview');
+        const pdfMode = document.getElementById('pdfPreview');
         let lines = [];
         let elementMap = new Map();
         let syncingFromInput = false;
@@ -56,9 +66,24 @@
         }
 
         function updatePreview() {
-            const cleaned = input.value.replace(/<!--\s*\{\{.*?\}\}\s*-->/g, '');
-            lines = cleaned.split('\n');
-            preview.innerHTML = marked.parse(cleaned);
+            const raw = input.value;
+            let processed;
+
+            if (pdfMode.checked) {
+                processed = raw
+                    .replace(/_{2,}\s*<!--\s*\{\{text:([^,}]+).*?\}\}\s*-->/g, (m, name) => `<input type="text" name="${name}" />`)
+                    .replace(/\[\s+]\s*<!--\s*\{\{check:([^,}]+).*?\}\}\s*-->/g, (m, name) => `<input type="checkbox" name="${name}" />`)
+                    .replace(/\(\s+\)\s*<!--\s*\{\{radio:([^,}]+),group=([^,}]+),value=([^,}]+).*?\}\}\s*-->/g,
+                        (m, _name, group, value) => `<input type="radio" name="${group}" value="${value}" />`)
+                    .replace(/\s*<!--\s*\{\{\s*pagebreak\s*\}\}\s*-->\s*/gi,
+                        '\n<div style="page-break-after: always;"></div>\n')
+                    .replace(/<!--\s*\{\{.*?\}\}\s*-->/g, '');
+            } else {
+                processed = raw.replace(/<!--\s*\{\{.*?\}\}\s*-->/g, '');
+            }
+
+            lines = processed.split('\n');
+            preview.innerHTML = marked.parse(processed);
             splitParagraphLines();
             elementMap.clear();
             const elements = Array.from(
@@ -105,6 +130,8 @@
         previewTab.addEventListener('click', showPreview);
 
         input.addEventListener('input', updatePreview);
+        htmlMode.addEventListener('change', updatePreview);
+        pdfMode.addEventListener('change', updatePreview);
 
         input.addEventListener('scroll', () => {
             if (syncingFromPreview) {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -63,3 +63,14 @@ tr.highlight > th {
 #markdownInput {
   flex: 1 1 auto;
 }
+
+#preview input[type="text"] {
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  padding: 2px 4px;
+}
+
+#preview input[type="checkbox"],
+#preview input[type="radio"] {
+  margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- add HTML/PDF toggle in preview pane
- render form controls in PDF mode using existing placeholder logic
- style preview inputs to mimic fillable fields

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689cdd7b433c83328d5d41ea1733273c