### PR TITLE
Add anti-forgery token to PDF generation form

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -26,6 +26,7 @@ namespace markdown_to_pdf.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public IActionResult GeneratePdf(string? markdown)
         {
             markdown ??= System.IO.File.ReadAllText(_samplePath);

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -16,6 +16,7 @@
 <div class="row">
     <div class="col-md-6 d-md-block" id="editorPane">
         <form method="post" asp-action="GeneratePdf">
+            @Html.AntiForgeryToken()
             <textarea id="markdownInput" name="markdown" class="form-control no-wrap" wrap="off">@Model</textarea>
             <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
         </form>


### PR DESCRIPTION
## Summary
- add anti-forgery validation attribute to GeneratePdf action
- insert anti-forgery token in GeneratePdf form

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e08f4d1c88332bfe27cbe7cc8573f