### PR TITLE
Add security headers middleware

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,16 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.Use(async (ctx, next) =>
+{
+    ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    ctx.Response.Headers["Referrer-Policy"] = "no-referrer";
+    ctx.Response.Headers["X-Frame-Options"] = "DENY";
+    ctx.Response.Headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=()";
+    ctx.Response.Headers["Content-Security-Policy"] =
+        "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self'; img-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';";
+    await next();
+});
 app.UseStaticFiles();
 
 app.UseRouting();


### PR DESCRIPTION
## Summary
- add middleware that sets security headers and restrictive CSP

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e177a92dc8332a1dd243c514747f6