### PR TITLE
Disable raw HTML and sanitize markdown output

### DIFF
--- a/MarkdownToPdf.Tests/MarkdownServiceTests.cs
+++ b/MarkdownToPdf.Tests/MarkdownServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using markdown_to_pdf.Services;
 using Xunit;
@@ -11,7 +12,7 @@ public class MarkdownServiceTests
     {
         var service = new MarkdownService();
         var html = service.RenderHtml("__ <!-- {{text:Name}} -->", true);
-        Assert.Contains("<input type=\"text\" name=\"Name\" />", html);
+        Assert.Contains("<input type=\"text\" name=\"Name\">", html);
     }
 
     [Fact]
@@ -30,5 +31,13 @@ public class MarkdownServiceTests
         var bytes = service.GeneratePdf("test");
         Assert.True(bytes.Length > 4);
         Assert.Equal("%PDF", Encoding.ASCII.GetString(bytes, 0, 4));
+    }
+
+    [Fact]
+    public void RenderHtml_RemovesScriptTags()
+    {
+        var service = new MarkdownService();
+        var html = service.RenderHtml("<script>alert('x')</script>", true);
+        Assert.DoesNotContain("<script>", html, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/markdown-to-pdf.csproj
+++ b/markdown-to-pdf.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="itext7" Version="8.0.2" />
     <PackageReference Include="itext7.pdfhtml" Version="5.0.0" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.2" />


### PR DESCRIPTION
## Summary
- prevent raw HTML in markdown by disabling HTML in default pipeline
- sanitize rendered HTML and whitelist form-related tags
- cover HTML sanitization with new unit test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689e1c1a9b8c83328252ce4e15314957