### PR TITLE
Stream PDF generation directly to response

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using markdown_to_pdf.Models;
 using markdown_to_pdf.Services;
 using Microsoft.AspNetCore.Hosting;
@@ -28,11 +29,20 @@ namespace markdown_to_pdf.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [RequestSizeLimit(2 * 1024 * 1024)]
-        public IActionResult GeneratePdf(string? markdown)
+        public async Task<IActionResult> GeneratePdf(string? markdown)
         {
-            markdown ??= System.IO.File.ReadAllText(_samplePath);
-            var pdf = _markdownService.GeneratePdf(markdown);
-            return File(pdf, "application/pdf", "sample.pdf");
+            if (markdown == null)
+            {
+                await using var fs = new FileStream(_samplePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+                using var reader = new StreamReader(fs);
+                markdown = await reader.ReadToEndAsync();
+            }
+
+            await _markdownService.GeneratePdf(markdown!, Response.Body);
+            return new FileStreamResult(Response.Body, "application/pdf")
+            {
+                FileDownloadName = "sample.pdf"
+            };
         }
 
         public IActionResult Privacy()

--- a/MarkdownToPdf.Tests/MarkdownServiceTests.cs
+++ b/MarkdownToPdf.Tests/MarkdownServiceTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using markdown_to_pdf.Services;
 using Xunit;
 
@@ -25,11 +27,13 @@ public class MarkdownServiceTests
     }
 
     [Fact]
-    public void GeneratePdf_ReturnsPdfBytes()
+    public async Task GeneratePdf_WritesPdfToStream()
     {
         var service = new MarkdownService();
-        var bytes = service.GeneratePdf("test");
-        Assert.True(bytes.Length > 4);
+        await using var ms = new MemoryStream();
+        await service.GeneratePdf("test", ms);
+        Assert.True(ms.Length > 4);
+        var bytes = ms.ToArray();
         Assert.Equal("%PDF", Encoding.ASCII.GetString(bytes, 0, 4));
     }
 


### PR DESCRIPTION
## Summary
- Generate PDFs directly into the HTTP response stream
- Read sample markdown asynchronously in controller
- Adjust tests to verify PDF stream output

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e223fbee083329871e907fd821c2a