### PR TITLE
Add comprehensive Markdown to PDF tests

### DIFF
--- a/MarkdownToPdf.Tests/HtmlSanitizationTests.cs
+++ b/MarkdownToPdf.Tests/HtmlSanitizationTests.cs
@@ -1,0 +1,16 @@
+using markdown_to_pdf.Services;
+using Xunit;
+
+namespace MarkdownToPdf.Tests;
+
+public class HtmlSanitizationTests
+{
+    [Fact]
+    public void RenderHtml_DisabledHtml_EncodesTags()
+    {
+        var service = new MarkdownService();
+        var html = service.RenderHtml("<b>bold</b>", false);
+        Assert.DoesNotContain("<b>bold</b>", html, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("&lt;b&gt;bold&lt;/b&gt;", html, System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/MarkdownToPdf.Tests/MarkdownToPdf.Tests.csproj
+++ b/MarkdownToPdf.Tests/MarkdownToPdf.Tests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <ProjectReference Include="../markdown-to-pdf.csproj" />
   </ItemGroup>
 

--- a/MarkdownToPdf.Tests/PdfGenerationTests.cs
+++ b/MarkdownToPdf.Tests/PdfGenerationTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Threading.Tasks;
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using markdown_to_pdf.Services;
+using Xunit;
+
+namespace MarkdownToPdf.Tests;
+
+public class PdfGenerationTests
+{
+    [Fact]
+    public async Task GeneratePdf_BasicMarkdown_ContainsRenderedText()
+    {
+        var service = new MarkdownService();
+        await using var ms = new MemoryStream();
+        await service.GeneratePdf("# Hello", ms);
+        using var pdf = new PdfDocument(new PdfReader(new MemoryStream(ms.ToArray())));
+        var text = PdfTextExtractor.GetTextFromPage(pdf.GetPage(1), new LocationTextExtractionStrategy());
+        Assert.Contains("Hello", text);
+    }
+
+    [Fact]
+    public void RenderHtml_ReplacesPagebreakSentinel()
+    {
+        var service = new MarkdownService();
+        var html = service.RenderHtml("First\n<!-- {{pagebreak}} -->\nSecond", true);
+        Assert.Contains("<div style=\"page-break-after: always", html);
+    }
+}

--- a/MarkdownToPdf.Tests/RequestValidationTests.cs
+++ b/MarkdownToPdf.Tests/RequestValidationTests.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using markdown_to_pdf.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Metadata;
+using Xunit;
+
+namespace MarkdownToPdf.Tests;
+
+public class RequestValidationTests
+{
+    [Fact]
+    public void GeneratePdf_HasRequestSizeLimit()
+    {
+        var method = typeof(HomeController).GetMethod("GeneratePdf");
+        var attr = method!.GetCustomAttribute<RequestSizeLimitAttribute>();
+        Assert.NotNull(attr);
+        var metadata = (IRequestSizeLimitMetadata)attr!;
+        Assert.Equal(2 * 1024 * 1024, metadata.MaxRequestBodySize);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -54,3 +54,5 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- verify Markdown is converted to PDF with expected text
- ensure page-break sentinel and HTML sanitization behavior
- check request size limit metadata

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e283ea1b48332bc2a29b6fc442aa8