### PR TITLE
Redesign layout with compact header and footer

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -58,6 +58,11 @@ namespace markdown_to_pdf.Controllers
             return View();
         }
 
+        public IActionResult About()
+        {
+            return View();
+        }
+
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
         {

--- a/Views/Home/About.cshtml
+++ b/Views/Home/About.cshtml
@@ -1,0 +1,5 @@
+@{
+    ViewData["Title"] = "About";
+}
+<h1>@ViewData["Title"]</h1>
+<p>Tool to convert markdown into PDFs.</p>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,40 +1,29 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
+@{
+    ViewData["Title"] = "Home";
 }
 
 @model string
 
-<ul class="nav nav-tabs d-md-none mb-3" id="mobileTabs">
-    <li class="nav-item">
-        <button class="nav-link active" id="editor-tab" type="button">Editor</button>
-    </li>
-    <li class="nav-item">
-        <button class="nav-link" id="preview-tab" type="button">Preview</button>
-    </li>
-</ul>
+<section class="text-center mb-5">
+    <h1 class="display-4">Markdown → PDF</h1>
+    <p class="lead text-muted">Instantly turn Markdown into sleek PDFs.</p>
+</section>
 
 <div class="row">
-    <div class="col-md-6 d-md-block" id="editorPane">
-        <form method="post" asp-action="GeneratePdf">
-            @Html.AntiForgeryToken()
-            <textarea id="markdownInput" name="markdown" class="form-control no-wrap" wrap="off">@Model</textarea>
-            <button type="submit" class="btn btn-primary mt-3">Generate PDF</button>
-        </form>
-    </div>
-    <div class="col-md-6 d-none d-md-block" id="previewPane">
-        <div class="d-flex justify-content-end mb-2">
-            <div class="btn-group btn-group-sm" role="group">
-                <input type="radio" class="btn-check" name="previewMode" id="htmlPreview" autocomplete="off" checked>
-                <label class="btn btn-outline-secondary" for="htmlPreview">HTML</label>
-                <input type="radio" class="btn-check" name="previewMode" id="pdfPreview" autocomplete="off">
-                <label class="btn btn-outline-secondary" for="pdfPreview">PDF</label>
-            </div>
+    <div class="col-md-8 mb-4">
+        <div class="surface p-3 h-100">
+            <form method="post" asp-action="GeneratePdf" class="h-100 d-flex flex-column">
+                @Html.AntiForgeryToken()
+                <textarea id="markdownInput" name="markdown" class="form-control no-wrap flex-grow-1" wrap="off">@Model</textarea>
+                <button type="submit" class="btn btn-primary mt-3 align-self-start">Generate PDF</button>
+            </form>
         </div>
-        <div id="preview" class="surface p-3 h-100"></div>
+    </div>
+    <div class="col-md-4 mb-4">
+        <div class="surface p-3">
+            <h2 class="h5">Tips</h2>
+            <p class="mb-1">Write Markdown on the left.</p>
+            <p class="mb-0">Press "Generate PDF" to download.</p>
+        </div>
     </div>
 </div>
-
-@section Scripts {
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="~/js/markdownEditor.js"></script>
-}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -9,10 +9,13 @@
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm surface mb-4">
+        <nav class="navbar surface sticky-top py-2 mb-4">
             <div class="container-fluid">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">markdown_to_pdf</a>
-                <div class="d-flex align-items-center ms-auto">
+                <a class="navbar-brand d-flex align-items-center" asp-area="" asp-controller="Home" asp-action="Index">
+                    <img src="~/favicon.ico" alt="Logo" width="24" height="24" class="me-2" />
+                    markdown_to_pdf
+                </a>
+                <div class="d-flex align-items-center ms-auto gap-2">
                     <button id="themeToggle" class="btn btn-link" aria-label="Toggle dark mode">
                         <svg id="sunIcon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.75V3m0 18v-1.75M4.75 12H3m18 0h-1.75M5.219 5.219l-.969-.969m15.5 15.5-.969-.969M5.219 18.781l-.969.969m15.5-15.5-.969.969M12 7a5 5 0 100 10 5 5 0 000-10z" />
@@ -21,19 +24,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
                         </svg>
                     </button>
-                    <button class="navbar-toggler ms-2" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon"></span>
-                    </button>
-                </div>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-end">
-                    <ul class="navbar-nav flex-grow-1">
-                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                        </li>
-                    </ul>
+                    <a href="https://github.com" target="_blank" rel="noopener" class="nav-link p-0">GitHub</a>
                 </div>
             </div>
         </nav>
@@ -44,9 +35,13 @@
         </main>
     </div>
 
-    <footer class="surface footer text-muted mt-4 p-3">
+    <footer class="surface text-muted small mt-4 py-2">
         <div class="container-fluid text-center">
-            &copy; 2025 - markdown_to_pdf - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+            <a asp-area="" asp-controller="Home" asp-action="Privacy" class="text-muted">Privacy</a>
+            ·
+            <a asp-area="" asp-controller="Home" asp-action="About" class="text-muted">About</a>
+            ·
+            <span>v@typeof(Program).Assembly.GetName().Version?.ToString(3)</span>
         </div>
     </footer>
     <script src="~/lib/jquery/dist/jquery.min.js"></script>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -41,7 +41,11 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 h1 {
-  background: linear-gradient(90deg, var(--color-accent), var(--color-accent-alt));
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-text) 70%, var(--color-accent)),
+    color-mix(in srgb, var(--color-text) 70%, var(--color-accent-alt))
+  );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }


### PR DESCRIPTION
## Summary
- Simplify header with logo, theme toggle, and GitHub link; remove navigation links and make it sticky.
- Replace home page with hero section and conversion/tips cards.
- Streamline footer with privacy, about, and version links plus subtle H1 gradient styling.

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689e4f4297a48332b794eee31c2c6824