### PR TITLE
Include sample markdown file in deployment

### DIFF
--- a/src/MarkdownToPdf.Web/markdown-to-pdf.csproj
+++ b/src/MarkdownToPdf.Web/markdown-to-pdf.csproj
@@ -11,4 +11,11 @@
     <ProjectReference Include="../MarkdownToPdf.Core/MarkdownToPdf.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Samples/**/*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- Ensure sample markdown file ships with the web project by copying the `Samples` folder to the build and publish output.

## Testing
- `dotnet test`
- `dotnet publish src/MarkdownToPdf.Web/markdown-to-pdf.csproj -c Release -o /tmp/publish`


------
https://chatgpt.com/codex/tasks/task_e_68a783d5f7bc83329c920f2c9087cfb3