### PR TITLE
Add privacy policy and usage blurb

### DIFF
--- a/src/MarkdownToPdf.Web/Views/Home/Index.cshtml
+++ b/src/MarkdownToPdf.Web/Views/Home/Index.cshtml
@@ -4,6 +4,18 @@
 
 @model string
 
+<div class="mb-4">
+    <h2>Why use Markdown-to-PDF?</h2>
+    <p>Managing multiple versions of the same document is a nightmare. One update in Word, another in a PDF, and another in a fillable form — and suddenly your documents are out of sync.</p>
+    <ul>
+        <li><strong>Write once in Markdown</strong> – developer-friendly, version-controllable, and fast.</li>
+        <li><strong>Generate PDFs instantly</strong>, including fillable versions if needed.</li>
+        <li><strong>Stay consistent</strong> across all formats without duplicate edits.</li>
+        <li><strong>Move faster</strong> with lightweight docs that are easy to revise.</li>
+    </ul>
+    <p>Stop fighting with Word and duplicated PDFs. Keep your docs in Markdown, convert on demand, and never worry about mismatched versions again.</p>
+</div>
+
 <ul class="nav nav-tabs d-md-none mb-3" id="mobileTabs">
     <li class="nav-item">
         <button class="nav-link active" id="editor-tab" type="button">Editor</button>

--- a/src/MarkdownToPdf.Web/Views/Home/Privacy.cshtml
+++ b/src/MarkdownToPdf.Web/Views/Home/Privacy.cshtml
@@ -1,6 +1,40 @@
-﻿@{
+@{
     ViewData["Title"] = "Privacy Policy";
 }
 <h1>@ViewData["Title"]</h1>
 
-<p>Use this page to detail your site's privacy policy.</p>
+<p><strong>Effective Date:</strong> August 21, 2025</p>
+
+<p>At md-pdf, your privacy is important to us. This policy explains what information we collect and how we use it.</p>
+
+<h2>1. Information We Collect</h2>
+<ul>
+    <li><strong>Uploaded Files:</strong> When you convert a Markdown file to PDF, the file is processed temporarily for conversion.</li>
+    <li><strong>Storage:</strong> We do not permanently store your files. Files are deleted immediately after processing.</li>
+    <li><strong>Analytics:</strong> We may use analytics tools (e.g., Google Analytics) to understand site usage. These collect anonymous data such as page views, browser type, and device type.</li>
+</ul>
+
+<h2>2. How We Use Information</h2>
+<ul>
+    <li>To provide and improve the file conversion service.</li>
+    <li>To monitor usage patterns and improve performance.</li>
+    <li>To communicate with you if you contact us directly.</li>
+</ul>
+
+<h2>3. Data Sharing</h2>
+<ul>
+    <li>We do not sell or share your files with third parties.</li>
+    <li>We may use trusted third-party services (such as hosting providers and analytics tools) under strict confidentiality agreements.</li>
+</ul>
+
+<h2>4. Security</h2>
+<p>We take reasonable measures to protect your files and personal data. However, no online service can guarantee absolute security.</p>
+
+<h2>5. Your Choices</h2>
+<ul>
+    <li>You may choose not to use the service if you do not want your files processed.</li>
+    <li>You may opt out of analytics cookies via your browser settings.</li>
+</ul>
+
+<h2>6. Contact Us</h2>
+<p>If you have any questions about this Privacy Policy, contact us at: <a href="https://github.com/cjbowman21/markdown-to-pdf">https://github.com/cjbowman21/markdown-to-pdf</a></p>


### PR DESCRIPTION
## Summary
- add detailed privacy policy page
- highlight "Why use Markdown-to-PDF?" on the homepage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a79524c3ec8332abb5b452e2233f35