### PR TITLE
Add WHY/HOW preview tab with tips and copy examples

### DIFF
--- a/src/MarkdownToPdf.Web/Samples/markdown1.txt
+++ b/src/MarkdownToPdf.Web/Samples/markdown1.txt
@@ -1,46 +1,12 @@
-# Fillable Questionnaire
-**123 S. Main St., Suite A**  
-**Springfield, NY 12345**  
-**555.123.1234 Toll Free**  
-**support@software-company.com**  
-**www.software-company.com**
+# Sample Markdown
 
----
+## Contact
+**Name:** ____ <!-- {{text:Contact.Name,width=200,overlay}} -->
 
-## Contacts
-
-**Chief Executive Officer:** ____ <!-- {{text:Contacts.CEO.Name,width=300,overlay}} -->
- * Email: ____ <!-- {{text:Contacts.CEO.Email,width=250,overlay}} -->
- * Phone: ____ <!-- {{text:Contacts.CEO.Phone,width=160,overlay}} -->  
-
-**President:** ____ <!-- {{text:Contacts.President.Name,width=300,overlay}} -->  
- * Email: ____ <!-- {{text:Contacts.President.Email,width=250,overlay}} --> 
- * Phone: ____ <!-- {{text:Contacts.President.Phone,width=160,overlay}} -->  
-
----
-
-## Questions
-
-### Company Details
-- Location: ____ <!-- {{text:Questions.CompanyDetails.Location,width=300,overlay}} -->  
-- Remote or on-location: Remote ( ) <!-- {{radio:Questions.CompanyDetails.Type,group=Questions.CompanyDetails.Type,value=Remote,overlay}} -->  On-Location ( ) <!-- {{radio:Questions.CompanyDetails.Type,group=Questions.CompanyDetails.Type,value=OnLocation,overlay}} -->  
----
-
-## Modules Questionnaire
-
-**Please indicate the areas you have expertise in:**
-
-| Area                     | Proficient        |
-|--------------------------|-------------------|
-| SQL                      | [ ] <!-- {{check:Areas.SQL,overlay}} --> |
-| .NET                     | [ ] <!-- {{check:Areas.NET,overlay}} --> |
-| JavaScript               | [ ] <!-- {{check:Areas.JavaScript,overlay}} --> |
-| Git                      | [ ] <!-- {{check:Areas.Git,overlay}} --> |
-
-
----
+## Preferences
+- Remote or on-location: Remote ( ) <!-- {{radio:Company.Type,group=Company.Type,value=Remote,overlay}} --> On-Location ( ) <!-- {{radio:Company.Type,group=Company.Type,value=OnLocation,overlay}} -->
+- Git experience? [ ] <!-- {{check:Skills.Git,overlay}} -->
 
 <!-- {{ pagebreak }} -->
-
-More details after page break
+More after page break
 

--- a/src/MarkdownToPdf.Web/Views/Home/Index.cshtml
+++ b/src/MarkdownToPdf.Web/Views/Home/Index.cshtml
@@ -4,33 +4,6 @@
 
 @model string
 
-<div class="mb-4">
-    <button type="button" class="btn btn-link p-0" data-bs-toggle="modal" data-bs-target="#whyModal">
-        Why use Markdown-to-PDF?
-    </button>
-</div>
-
-<div class="modal fade" id="whyModal" tabindex="-1" aria-labelledby="whyModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="whyModalLabel">Why use Markdown-to-PDF?</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <p>Managing multiple versions of the same document is a nightmare. One update in Word, another in a PDF, and another in a fillable form — and suddenly your documents are out of sync.</p>
-                <ul>
-                    <li><strong>Write once in Markdown</strong> – developer-friendly, version-controllable, and fast.</li>
-                    <li><strong>Generate PDFs instantly</strong>, including fillable versions if needed.</li>
-                    <li><strong>Stay consistent</strong> across all formats without duplicate edits.</li>
-                    <li><strong>Move faster</strong> with lightweight docs that are easy to revise.</li>
-                </ul>
-                <p>Stop fighting with Word and duplicated PDFs. Keep your docs in Markdown, convert on demand, and never worry about mismatched versions again.</p>
-            </div>
-        </div>
-    </div>
-</div>
-
 <ul class="nav nav-tabs d-md-none mb-3" id="mobileTabs">
     <li class="nav-item">
         <button class="nav-link active" id="editor-tab" type="button">Editor</button>
@@ -82,8 +55,48 @@
             <li class="nav-item">
                 <button class="nav-link" id="pdfModeTab" type="button">PDF</button>
             </li>
+            <li class="nav-item">
+                <button class="nav-link" id="whyModeTab" type="button">WHY/HOW</button>
+            </li>
         </ul>
         <div id="preview" class="surface p-3 flex-grow-1 overflow-auto"></div>
+        <div id="whyContent" class="surface p-3 flex-grow-1 overflow-auto d-none">
+            <h5>Why use Markdown-to-PDF?</h5>
+            <p>Managing multiple versions of the same document is a nightmare. One update in Word, another in a PDF, and another in a fillable form — and suddenly your documents are out of sync.</p>
+            <ul>
+                <li><strong>Write once in Markdown</strong> – developer-friendly, version-controllable, and fast.</li>
+                <li><strong>Generate PDFs instantly</strong>, including fillable versions if needed.</li>
+                <li><strong>Stay consistent</strong> across all formats without duplicate edits.</li>
+                <li><strong>Move faster</strong> with lightweight docs that are easy to revise.</li>
+            </ul>
+            <p>Stop fighting with Word and duplicated PDFs. Keep your docs in Markdown, convert on demand, and never worry about mismatched versions again.</p>
+            <h5 class="mt-4">How to add fillable fields</h5>
+            <p>Use the snippets below to create interactive elements in your PDF. Click <em>Copy</em> to add them to your markdown.</p>
+            <div class="mb-3">
+                <div class="d-flex align-items-start">
+                    <pre class="flex-grow-1 bg-light p-2"><code id="textExample">Name: ____ &lt;!-- {{text:Contact.Name,width=200,overlay}} --&gt;</code></pre>
+                    <button class="btn btn-outline-secondary btn-sm ms-2 copy-example" data-copy-target="textExample">Copy</button>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="d-flex align-items-start">
+                    <pre class="flex-grow-1 bg-light p-2"><code id="checkExample">- Accept terms [ ] &lt;!-- {{check:AcceptTerms,overlay}} --&gt;</code></pre>
+                    <button class="btn btn-outline-secondary btn-sm ms-2 copy-example" data-copy-target="checkExample">Copy</button>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="d-flex align-items-start">
+                    <pre class="flex-grow-1 bg-light p-2"><code id="radioExample">Remote or on-location: Remote ( ) &lt;!-- {{radio:Questions.CompanyDetails.Type,group=Questions.CompanyDetails.Type,value=Remote,overlay}} --&gt; On-Location ( ) &lt;!-- {{radio:Questions.CompanyDetails.Type,group=Questions.CompanyDetails.Type,value=OnLocation,overlay}} --&gt;</code></pre>
+                    <button class="btn btn-outline-secondary btn-sm ms-2 copy-example" data-copy-target="radioExample">Copy</button>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="d-flex align-items-start">
+                    <pre class="flex-grow-1 bg-light p-2"><code id="pageExample">&lt;!-- {{ pagebreak }} --&gt;</code></pre>
+                    <button class="btn btn-outline-secondary btn-sm ms-2 copy-example" data-copy-target="pageExample">Copy</button>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/src/MarkdownToPdf.Web/wwwroot/js/markdownEditor.js
+++ b/src/MarkdownToPdf.Web/wwwroot/js/markdownEditor.js
@@ -8,7 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const previewTab = document.getElementById('preview-tab');
     const htmlModeTab = document.getElementById('htmlModeTab');
     const pdfModeTab = document.getElementById('pdfModeTab');
-    if (!input || !preview || !editorTab || !previewTab || !htmlModeTab || !pdfModeTab) {
+    const whyModeTab = document.getElementById('whyModeTab');
+    const whyContent = document.getElementById('whyContent');
+    if (!input || !preview || !editorTab || !previewTab || !htmlModeTab || !pdfModeTab || !whyModeTab || !whyContent) {
         return;
     }
     let previewMode = 'html';
@@ -103,13 +105,26 @@ document.addEventListener('DOMContentLoaded', () => {
         previewMode = 'html';
         htmlModeTab.classList.add('active');
         pdfModeTab.classList.remove('active');
+        whyModeTab.classList.remove('active');
+        whyContent.classList.add('d-none');
+        preview.classList.remove('d-none');
         updatePreview();
     });
     pdfModeTab.addEventListener('click', () => {
         previewMode = 'pdf';
         pdfModeTab.classList.add('active');
         htmlModeTab.classList.remove('active');
+        whyModeTab.classList.remove('active');
+        whyContent.classList.add('d-none');
+        preview.classList.remove('d-none');
         updatePreview();
+    });
+    whyModeTab.addEventListener('click', () => {
+        whyModeTab.classList.add('active');
+        htmlModeTab.classList.remove('active');
+        pdfModeTab.classList.remove('active');
+        preview.classList.add('d-none');
+        whyContent.classList.remove('d-none');
     });
 
     input.addEventListener('scroll', () => {
@@ -153,6 +168,18 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     input.addEventListener('mouseleave', clearHighlight);
+
+    document.querySelectorAll('.copy-example').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-copy-target');
+            const text = document.getElementById(targetId)?.innerText;
+            if (text) {
+                navigator.clipboard.writeText(text.trim());
+                btn.textContent = 'Copied!';
+                setTimeout(() => (btn.textContent = 'Copy'), 2000);
+            }
+        });
+    });
 
     updatePreview();
 });


### PR DESCRIPTION
## Summary
- replace Why modal with WHY/HOW preview tab containing usage tips
- provide copyable examples for text, checkbox, radio, and page break fields
- simplify bundled sample markdown

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b085c780648332a10ce6c9034555bd