### PR TITLE
Preserve PDF form fields when overlaying backgrounds

### DIFF
--- a/tests/MarkdownToPdf.Tests/PdfGenerationTests.cs
+++ b/tests/MarkdownToPdf.Tests/PdfGenerationTests.cs
@@ -4,6 +4,7 @@ using iText.Kernel.Pdf;
 using iText.Kernel.Pdf.Canvas.Parser;
 using iText.Kernel.Pdf.Canvas.Parser.Listener;
 using MarkdownToPdf.Core.Services;
+using iText.Forms;
 using Xunit;
 
 namespace MarkdownToPdf.Tests;
@@ -27,5 +28,28 @@ public class PdfGenerationTests
         var service = new MarkdownService();
         var html = service.RenderHtml("First\n<!-- {{pagebreak}} -->\nSecond", true);
         Assert.Contains("<div style=\"page-break-after: always", html);
+    }
+
+    [Fact]
+    public async Task GeneratePdf_WithTextField_PreservesAcroForm()
+    {
+        var service = new MarkdownService();
+        await using var output = new MemoryStream();
+
+        await using var bg = new MemoryStream();
+        using (var writer = new PdfWriter(bg))
+        {
+            writer.SetCloseStream(false);
+            using var doc = new PdfDocument(writer);
+            doc.AddNewPage();
+        }
+        bg.Position = 0;
+
+        await service.GeneratePdf("__ <!-- {{text:Name}} -->", output, bg);
+
+        using var pdf = new PdfDocument(new PdfReader(new MemoryStream(output.ToArray())));
+        var form = PdfAcroForm.GetAcroForm(pdf, false);
+        Assert.NotNull(form);
+        Assert.NotNull(form.GetField("Name"));
     }
 }


### PR DESCRIPTION
## Summary
- keep form fields by copying generated pages directly instead of flattening them
- ensure background PDFs are drawn beneath content while preserving AcroForms
- add regression test validating text field remains fillable

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b700935b5c833291553b9b2f71b75a