### PR TITLE
Improve footer tools layout

### DIFF
--- a/src/MarkdownToPdf.Web/Views/Home/Index.cshtml
+++ b/src/MarkdownToPdf.Web/Views/Home/Index.cshtml
@@ -106,48 +106,44 @@
     <footer class="fixed-bottom surface border-top p-3">
         <div class="container-fluid">
             <div class="collapse d-md-block mb-2" id="optionsCollapse">
-                <div class="row g-3 align-items-center">
-                    <div class="col-md-4 d-flex align-items-center">
+                <ul class="list-unstyled d-flex flex-wrap align-items-center mb-2">
+                    <li class="d-flex align-items-center me-3 mb-2">
                         <label for="fileName" class="form-label mb-0 me-2">Filename:</label>
-                        <input type="text" id="fileName" name="fileName" form="pdfForm" class="form-control form-control-sm" placeholder="document" />
-                    </div>
-                    <div class="col-md-5 d-flex align-items-center">
-                        <label for="letterheadPdf" class="form-label mb-0 me-2">Add Background:</label>
-                        <input type="file" id="letterheadPdf" name="letterheadPdf" form="pdfForm" class="form-control form-control-sm" accept=".pdf" />
+                        <input type="text" id="fileName" name="fileName" form="pdfForm" class="form-control form-control-sm w-auto" placeholder="document" />
+                    </li>
+                    <li class="d-flex align-items-center me-3 mb-2">
+                        <label for="letterheadPdf" class="form-label mb-0 me-2">Background:</label>
+                        <input type="file" id="letterheadPdf" name="letterheadPdf" form="pdfForm" class="form-control form-control-sm w-auto" accept=".pdf" />
                         <button type="button" id="removeLetterhead" class="btn btn-outline-secondary btn-sm ms-2">Remove</button>
-                    </div>
-                    <div class="col-md-3 d-flex align-items-center">
-                        <div class="form-check">
+                    </li>
+                    <li class="me-3 mb-2">
+                        <div class="form-check mb-0 d-flex align-items-center">
                             <input class="form-check-input" type="checkbox" value="true" id="applyOverlay" name="applyOverlay" form="pdfForm" checked>
-                            <label class="form-check-label" for="applyOverlay">
-                                Apply Background
-                            </label>
+                            <label class="form-check-label ms-2" for="applyOverlay">Apply Background</label>
                         </div>
-                    </div>
-                    <div class="col-md-3 d-flex align-items-center">
+                    </li>
+                    <li class="d-flex align-items-center me-3 mb-2">
                         <label for="offsetYDisplay" class="form-label mb-0 me-2">Top Offset:</label>
-                        <input type="number" id="offsetYDisplay" class="form-control form-control-sm me-2" placeholder="0" value="0" step="1" />
+                        <input type="number" id="offsetYDisplay" class="form-control form-control-sm me-2 w-auto" placeholder="0" value="0" step="1" />
                         <select id="offsetYUnit" class="form-select form-select-sm w-auto">
                             <option value="pt" selected>pt</option>
                             <option value="in">in</option>
                             <option value="mm">mm</option>
                         </select>
                         <input type="hidden" id="offsetY" name="offsetY" form="pdfForm" value="0" />
-                    </div>
-                    <div class="col-md-3 d-flex align-items-center">
+                    </li>
+                    <li class="d-flex align-items-center mb-2">
                         <label for="offsetXDisplay" class="form-label mb-0 me-2">Left Offset:</label>
-                        <input type="number" id="offsetXDisplay" class="form-control form-control-sm me-2" placeholder="0" value="0" step="1" />
+                        <input type="number" id="offsetXDisplay" class="form-control form-control-sm me-2 w-auto" placeholder="0" value="0" step="1" />
                         <select id="offsetXUnit" class="form-select form-select-sm w-auto">
                             <option value="pt" selected>pt</option>
                             <option value="in">in</option>
                             <option value="mm">mm</option>
                         </select>
                         <input type="hidden" id="offsetX" name="offsetX" form="pdfForm" value="0" />
-                    </div>
-                    <div class="col-12">
-                        <div class="form-text">If added, the generated PDF is drawn on top of the background. Use Top/Left offsets to avoid overlapping a logo or header on your background. One-page backgrounds repeat on all pages; multi-page backgrounds map page-by-page.</div>
-                    </div>
-                </div>
+                    </li>
+                </ul>
+                <div class="form-text">If added, the generated PDF is drawn on top of the background. Use Top/Left offsets to avoid overlapping a logo or header on your background. One-page backgrounds repeat on all pages; multi-page backgrounds map page-by-page.</div>
             </div>
             <div class="d-flex justify-content-end align-items-center">
                 <button class="btn btn-outline-secondary me-2 d-md-none" type="button" data-bs-toggle="collapse" data-bs-target="#optionsCollapse" aria-expanded="false" aria-controls="optionsCollapse">&#9650;</button>


### PR DESCRIPTION
## Summary
- Reformat bottom tools section into a flex-wrapped list for cleaner alignment
- Shorten labels and reduce control widths for a tidier layout

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b7049e96ec83329951363265daf51b